### PR TITLE
add playtester ping and fix initial bot setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cogs/__pycache__
 data/
 Logs/
 __pycache__/
+config.toml

--- a/example.config.toml
+++ b/example.config.toml
@@ -9,6 +9,7 @@ allowedusers = "data/allowedusers.json"
 
 [channels]
 report-users-channel-id = 123456789 # Replace me!
+playtesters-channel-id = 123456789 # Replace me!
 
 [tokens]
 discord = "REPLACE-ME"

--- a/reaper/cogs/playtester_ping.py
+++ b/reaper/cogs/playtester_ping.py
@@ -66,8 +66,8 @@ class PlayTesterPing(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        playtestPingChannel = self.bot.get_channel(936678773150081055)
-        thunderstoreReleaseChannel = self.bot.get_channel(939573786355859498)
+        playtestPingChannel = self.bot.get_channel(globals.config["channels"]["report-users-channel-id"])
+        thunderstoreReleaseChannel = self.bot.get_channel(globals.config["channels"]["report-users-channel-id"])
 
         if message.author == self.bot.user:
             return
@@ -105,6 +105,28 @@ Make sure your release channel is still set to `Northstar release candidate`, an
                     embed=embed,
                 )
                 await pingMessage.create_thread(name=rcVersion)
+
+    @commands.hybrid_command()
+    async def pingplaytesters(self, ctx):
+        playtestPingChannel = self.bot.get_channel(globals.config["channels"]["report-users-channel-id"])
+        playtester_role = None
+
+        authorized = False
+        for role in ctx.author.roles:
+            if role.name == "Contributor" or role.name == "Modder": # there's a better way of doing this by adding a decorator but this works for now since it's the only command that checks for this
+                authorized = True
+                
+        for role in ctx.guild.roles:
+            if role.name == "Playtester":
+                playtester_role = role
+        
+        if not playtester_role:
+            return await ctx.send("Could not find playtester role. Does it exist?")
+
+        if authorized:
+            await playtestPingChannel.send(playtester_role.mention)
+        else:
+            await ctx.send("You don't have permission to use this command!")
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/reaper/main.py
+++ b/reaper/main.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 import tomllib
+import os
 from util import globals
 
 # Load config into global var
@@ -10,6 +11,10 @@ with open("config.toml", "rb") as file:
     tokens = globals.config["tokens"]
 import util.json_handler
 
+if not os.path.exists("data"):
+    os.makedirs("data")
+
+util.json_handler.init_json()
 allowed_users = util.json_handler.load_allowed_users()
 
 COGS = (
@@ -110,5 +115,4 @@ async def setstatus(ctx, status: str):
         await ctx.send("You don't have permission to use this command!", ephemeral=True)
 
 
-util.json_handler.init_json()
 bot.run(tokens["discord"])

--- a/reaper/util/json_handler.py
+++ b/reaper/util/json_handler.py
@@ -4,13 +4,13 @@ from util import globals
 
 
 def init_json():
-    if os.path.isfile(noreplylist) == False:
+    if not os.path.isfile(noreplylist):
         new_json(noreplylist)
-    if os.path.isfile(allowedchannels) == False:
+    if not os.path.isfile(allowedchannels):
         new_json(allowedchannels)
-    if os.path.isfile(neverreplylist) == False:
+    if not os.path.isfile(neverreplylist):
         new_json(neverreplylist)
-    if os.path.isfile(allowedusers) == False:
+    if not os.path.isfile(allowedusers):
         new_json(allowedusers)
 
 


### PR DESCRIPTION
This PR creates a playtester ping command, fixes the first time run bot setup, and has some small cleanups. Later, I am going to make another PR which does cleanups across the whole bot mainly to remove hardcoded values.

Most importantly, this PR deletes `config.toml` and replaces it with `example.config.toml` to allow for easier testing. When actually running the bot, you will need to create `config.toml` yourself.

I tested this PR on my own private server with dummy roles.

Edit: Whoops, looks like I was 3 minutes late to the draw. #3 