### PR TITLE
fix: Define logging configuration in every source file

### DIFF
--- a/reaper/cogs/auto_response.py
+++ b/reaper/cogs/auto_response.py
@@ -1,6 +1,10 @@
 import logging
+import coloredlogs
 
 logger = logging.getLogger(__name__)
+coloredlogs.install(
+    level="DEBUG", logger=logger, fmt="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 import datetime
 import discord

--- a/reaper/cogs/global_replies.py
+++ b/reaper/cogs/global_replies.py
@@ -1,6 +1,10 @@
 import logging
+import coloredlogs
 
 logger = logging.getLogger(__name__)
+coloredlogs.install(
+    level="DEBUG", logger=logger, fmt="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 import discord
 import util.json_handler

--- a/reaper/cogs/image_response.py
+++ b/reaper/cogs/image_response.py
@@ -1,6 +1,10 @@
 import logging
+import coloredlogs
 
 logger = logging.getLogger(__name__)
+coloredlogs.install(
+    level="DEBUG", logger=logger, fmt="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 from PIL import Image
 import pytesseract

--- a/reaper/cogs/log_reading.py
+++ b/reaper/cogs/log_reading.py
@@ -1,6 +1,10 @@
 import logging
+import coloredlogs
 
 logger = logging.getLogger(__name__)
+coloredlogs.install(
+    level="DEBUG", logger=logger, fmt="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 import discord
 from discord.ext import commands

--- a/reaper/cogs/mod_search.py
+++ b/reaper/cogs/mod_search.py
@@ -1,6 +1,10 @@
 import logging
+import coloredlogs
 
 logger = logging.getLogger(__name__)
+coloredlogs.install(
+    level="DEBUG", logger=logger, fmt="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 from discord.ext import commands
 import requests

--- a/reaper/cogs/playtester_ping.py
+++ b/reaper/cogs/playtester_ping.py
@@ -1,6 +1,10 @@
 import logging
+import coloredlogs
 
 logger = logging.getLogger(__name__)
+coloredlogs.install(
+    level="DEBUG", logger=logger, fmt="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 import discord
 from discord.ext import commands

--- a/reaper/util/master_status.py
+++ b/reaper/util/master_status.py
@@ -1,6 +1,10 @@
 import logging
+import coloredlogs
 
 logger = logging.getLogger(__name__)
+coloredlogs.install(
+    level="DEBUG", logger=logger, fmt="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 import requests
 


### PR DESCRIPTION
For some reason the logging configuration is not inherited. This approach is ugly but works for now.