### PR TITLE
feat: Check channel before proxy pinging playtesters

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -12,6 +12,11 @@ sentiment-analysis-cache = 50 # How many messages to check before warning modera
 [channels]
 report-users-channel-id = 123456789 # Replace me!
 playtesters-channel-id = 123456789 # Replace me!
+playtester-proxy-ping-allowed-channel-ids = [
+    123, # Replace me!
+    456, # Replace me!
+    789, # Replace me!
+]
 thunderstore-releases-channel-id = 123456789 # Replace me!
 sentiment-analysis-channels = [
     123, # Replace me!

--- a/reaper/cogs/playtester_ping_proxy.py
+++ b/reaper/cogs/playtester_ping_proxy.py
@@ -31,6 +31,16 @@ class PlayTesterPingProxy(commands.Cog):
             await ctx.send("Missing perms to ping playtesters", ephemeral=True)
             return
 
+        if (
+            not ctx.channel.id
+            in globals.config["channels"]["playtester-proxy-ping-allowed-channel-ids"]
+        ):
+            await ctx.send(
+                f"Not allowed to ping in this channel (#{ctx.channel.name})",
+                ephemeral=True,
+            )
+            return
+
         playtester_role_id = globals.config["roles"]["playtester-role-id"]
         logger.info(f"{ctx.author.display_name} pinged playtesters")
         await ctx.send(f"<@&{playtester_role_id}>")


### PR DESCRIPTION
Check channel before proxy pinging playtesters to only allow specific channels to prevent (accidentally) pinging playtesters in irrelevant channels.