### PR TITLE
Stop execution if variable not set

### DIFF
--- a/reaper/cogs/playtester_ping.py
+++ b/reaper/cogs/playtester_ping.py
@@ -37,6 +37,9 @@ def getLatestDiscussion():
         response = requests.post(url, json={"query": query}, headers=headers)
         if response.status_code == 200:
             raw_data = response.json()
+        else:
+            logger.warn(f"GitHub API returned HTTP code: {response.status_code}")
+            return None
 
     except requests.exceptions.RequestException as err:
         logger.warn(f"GitHub API request failed: {err}")


### PR DESCRIPTION
Closes #33

This PR stops execution when the GitHub API returns a status code that isn't 200.