### PR TITLE
build: Set vscode settings flake8 args

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "flake8.args": [
+        "--ignore=E501,E402,W503"
+    ],
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true


### PR DESCRIPTION
Adds vscode settings entry for the flake8 extension which errors and warnings to ignore

Taken from #36 