### PR TITLE
build: Add vscode setting for paths to look at for imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "python.analysis.extraPaths": [
+        "./reaper"
+    ],
     "flake8.args": [
         "--ignore=E501,E402,W503"
     ],


### PR DESCRIPTION
Add vscode setting for paths to look at for imports as otherwise it seems to fail to detect some of the libraries that are part of the project


Without this change:

![image](https://github.com/user-attachments/assets/236ac768-8587-4767-9ae9-81236788483e)
