### PR TITLE
ci: Add ruff linter action

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -14,4 +14,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff
       - name: Run Ruff
-        run: ruff check --output-format=github --ignore E402 .
+        run: ruff check --output-format=github --ignore=E402 .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,6 @@
 name: Ruff linter
 on: [push, pull_request]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,5 @@
 name: Ruff linter
-on: push
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,4 +14,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff
       - name: Run Ruff
-        run: ruff check --output-format=github .
+        run: ruff check --output-format=github --ignore E402 .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,17 @@
+name: Ruff linter
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run Ruff
+        run: ruff check --output-format=github .

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,9 @@
     "flake8.args": [
         "--ignore=E501,E402,W503"
     ],
+    "ruff.lint.args": [
+        "--ignore=E402"
+    ],
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true

--- a/reaper/cogs/install_channel_embed.py
+++ b/reaper/cogs/install_channel_embed.py
@@ -58,7 +58,7 @@ class InstallationChannel(commands.Cog):
     ):  # Yes, this gives an "Interaction failed" error. This is intended. This is so only the embeds show and no "x person used slash command" text appears
         allowed_users = util.json_handler.load_allowed_users()
 
-        if not str(ctx.author.id) in allowed_users:
+        if str(ctx.author.id) not in allowed_users:
             await ctx.channel.send(
                 "You don't have permission to use this command!", ephemeral=True
             )


### PR DESCRIPTION
Ruff is a new supported python linter. Since the flake8 action has an expire date I figured it would be good to add Ruff as a solution.

Pros:
- Ruff keeps things pythonic and readable
- Ruff does a lot of the same things flake8 does
- Ruff does not require anything to annotate PRs and commits and instead does it out of the box
- Ruff is a lot faster than flake8