### PR TITLE
ci: Use tagged version of black linting action

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: jpetrucciani/black-check@master
+    - uses: jpetrucciani/black-check@24.8.0

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: jpetrucciani/black-check@24.8.0
+    - uses: jpetrucciani/black-check@24.10.0


### PR DESCRIPTION
ideally we swap back to the master branch when the action is fixed