### PR TITLE
fix: Use `logger.warning` instead of `logger.warn`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.ruff.lint]
+select = [
+    "G010", # Add check for logger.warn
+]
 extend-ignore = [
     "E402", # Ignore: Module level import not at top of file
 ]

--- a/reaper/cogs/auto_response.py
+++ b/reaper/cogs/auto_response.py
@@ -117,7 +117,7 @@ class AutoResponse(commands.Cog):
             or message.channel.id != self.last_channel
         ):
             self.last_channel = message.channel.id
-            logger.warn("Tried to send message while on cooldown! Didn't send message!")
+            logger.warning("Tried to send message while on cooldown! Didn't send message!")
             return
 
         if not allow_replies():

--- a/reaper/cogs/auto_response.py
+++ b/reaper/cogs/auto_response.py
@@ -117,7 +117,9 @@ class AutoResponse(commands.Cog):
             or message.channel.id != self.last_channel
         ):
             self.last_channel = message.channel.id
-            logger.warning("Tried to send message while on cooldown! Didn't send message!")
+            logger.warning(
+                "Tried to send message while on cooldown! Didn't send message!"
+            )
             return
 
         if not allow_replies():

--- a/reaper/cogs/mod_search.py
+++ b/reaper/cogs/mod_search.py
@@ -91,7 +91,7 @@ class ModSearch(commands.Cog):
                 data = response.json()
 
         except requests.exceptions.RequestException as err:
-            logger.warn(err)
+            logger.warning(err)
             return
 
         mods = {}

--- a/reaper/cogs/playtester_ping_release_candidate.py
+++ b/reaper/cogs/playtester_ping_release_candidate.py
@@ -45,7 +45,7 @@ def get_latest_discussion():
             return None
 
     except requests.exceptions.RequestException as err:
-        logger.warn(f"GitHub API request failed: {err}")
+        logger.warning(f"GitHub API request failed: {err}")
         return None
 
     discussion_post = {
@@ -68,7 +68,7 @@ def get_latest_release_name():
         )
 
     except requests.exceptions.RequestException as err:
-        logger.warn(f"GitHub API request failed: {err}")
+        logger.warning(f"GitHub API request failed: {err}")
         return None
 
     return response.json()[0]["tag_name"]

--- a/reaper/util/master_status.py
+++ b/reaper/util/master_status.py
@@ -20,5 +20,5 @@ def is_master_down():
         else:
             return True
     except requests.exceptions.RequestException as err:
-        logger.warn(f"Encountered exception while requesting MS: {err}")
+        logger.warning(f"Encountered exception while requesting MS: {err}")
         return None


### PR DESCRIPTION
`logging.warn` is deprecated in favour of `logging.warning`

See [`G010`](https://docs.astral.sh/ruff/rules/logging-warn/)